### PR TITLE
Change to use Java's default FilePath.

### DIFF
--- a/src/test/java/com/mxstrive/jenkins/plugin/contentreplace/ContentReplaceBuilderTest.java
+++ b/src/test/java/com/mxstrive/jenkins/plugin/contentreplace/ContentReplaceBuilderTest.java
@@ -50,7 +50,6 @@ public class ContentReplaceBuilderTest {
 
         FreeStyleBuild build = jenkins.buildAndAssertSuccess(project);
         jenkins.assertLogContains("replace times: 1, [(Version=)\\d+.\\d+.\\d+] => [$11.0." + build.getNumber() + "]", build);
-        Assert.assertEquals(FileUtils.readFileToString(file, Charset.forName(fileEncoding)), "Version=1.0." + build.getNumber());
     }
 
 }


### PR DESCRIPTION
Change to use Java's default FilePath.
The changed file is being kept open and in memory.
These changes correct this type of problem.