### PR TITLE
Feature Quiet / Verbose mode

### DIFF
--- a/src/main/java/com/mxstrive/jenkins/plugin/contentreplace/ContentReplaceBuilder.java
+++ b/src/main/java/com/mxstrive/jenkins/plugin/contentreplace/ContentReplaceBuilder.java
@@ -136,7 +136,9 @@ public class ContentReplaceBuilder extends Builder implements SimpleBuildStep {
 				String line = lines.get(i);
 				String newLine = pattern.matcher(line).replaceFirst(replace);
 				lines.set(i, newLine);
-				log.println("   > replace : [" + line + "] => [" + newLine + "]");
+				if (cfg.isVerbose()) {
+					log.println("   > replace : [" + line + "] => [" + newLine + "]");
+				}
 			}
 			log.println("   > replace times: " + matchedLineIndexs.size() + ", [" + cfg.getSearch() + "] => [" + replace
 					+ "]");

--- a/src/main/java/com/mxstrive/jenkins/plugin/contentreplace/FileContentReplaceItemConfig.java
+++ b/src/main/java/com/mxstrive/jenkins/plugin/contentreplace/FileContentReplaceItemConfig.java
@@ -6,6 +6,7 @@ import java.util.regex.PatternSyntaxException;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
 import hudson.Extension;
@@ -18,12 +19,18 @@ public class FileContentReplaceItemConfig extends AbstractDescribableImpl<FileCo
 	private String search;
 	private String replace;
 	private int matchCount;
+	private boolean verbose;
 
 	@DataBoundConstructor
 	public FileContentReplaceItemConfig(String search, String replace, int matchCount) {
 		this.search = StringUtils.strip(search);
 		this.replace = StringUtils.strip(replace);
 		this.matchCount = matchCount;
+	}
+
+	@DataBoundSetter
+	public void setVerbose(boolean verbose) {
+		this.verbose = verbose;
 	}
 
 	public String getSearch() {
@@ -36,6 +43,10 @@ public class FileContentReplaceItemConfig extends AbstractDescribableImpl<FileCo
     
 	public int getMatchCount() {
 		return matchCount;
+	}
+
+	public boolean isVerbose() {
+		return verbose;
 	}
 
 	@Symbol("fileContentReplaceItemConfig")

--- a/src/main/resources/com/mxstrive/jenkins/plugin/contentreplace/FileContentReplaceItemConfig/config.jelly
+++ b/src/main/resources/com/mxstrive/jenkins/plugin/contentreplace/FileContentReplaceItemConfig/config.jelly
@@ -8,9 +8,10 @@
 			width: 90px;
 			text-align: right;
 		}
-		[name="_.search"] { width: calc(50% - 170px); }
-		[name="_.replace"] { width: calc(50% - 170px); }
-		[name="_.matchCount"] { width: 40px; margin-left: 4px;}
+		[name="_.search"] { width: calc(40% - 170px); }
+		[name="_.replace"] { width: calc(40% - 170px); }
+		[name="_.matchCount"] { width: calc(20% - 170px); }
+		[name="_.verbose"]{ width: 40px; margin-left: 4px;}
 	</style>
 	<f:entry field="forHelp">
 		<span class="item-name">${%Search}</span>
@@ -19,5 +20,7 @@
 		<f:textbox field="replace"/>
 		<span class="item-name">${%MatchCount}</span>
 		<f:number field="matchCount" default="0"/>
+		<span class="item-name">${%Verbose}</span>
+		<f:checkbox field="verbose"/>
 	</f:entry>
 </j:jelly>

--- a/src/main/resources/com/mxstrive/jenkins/plugin/contentreplace/FileContentReplaceItemConfig/config.properties
+++ b/src/main/resources/com/mxstrive/jenkins/plugin/contentreplace/FileContentReplaceItemConfig/config.properties
@@ -1,3 +1,4 @@
 Search=Regex search
 Replace=Replace with
 MatchCount=Match count
+Verbose=Verbose output

--- a/src/main/resources/com/mxstrive/jenkins/plugin/contentreplace/FileContentReplaceItemConfig/help-forHelp.html
+++ b/src/main/resources/com/mxstrive/jenkins/plugin/contentreplace/FileContentReplaceItemConfig/help-forHelp.html
@@ -4,5 +4,6 @@
 		<li>You can use variables enclosed in ${}. e.g. $11.0.${BUILD_ID}</li>
 		<li>So, The string "Version=0.0.1" would be replace to Version=1.0.9 when the value of BUILD_ID is 9</li>
 		<li>Set "Match count" to 0 will do replace all</li>
+		<li>Check "Verbose" to display in the console all the replacements made.</li>
 	</ul>
 </div>

--- a/src/test/java/com/mxstrive/jenkins/plugin/contentreplace/ContentReplaceBuilderTest.java
+++ b/src/test/java/com/mxstrive/jenkins/plugin/contentreplace/ContentReplaceBuilderTest.java
@@ -43,12 +43,26 @@ public class ContentReplaceBuilderTest {
     }
 
     @Test
-    public void testBuild() throws Exception {
+    public void testBuildQuiet() throws Exception {
         FreeStyleProject project = jenkins.createFreeStyleProject();
         ContentReplaceBuilder builder = new ContentReplaceBuilder(configs);
         project.getBuildersList().add(builder);
 
         FreeStyleBuild build = jenkins.buildAndAssertSuccess(project);
+        jenkins.assertLogNotContains("   > replace : [Version=0.0.0] => [Version=1.0." + build.getNumber() + "]", build);
+        jenkins.assertLogContains("   > replace times: 1, [(Version=)\\d+.\\d+.\\d+] => [$11.0." + build.getNumber() + "]", build);
+        Assert.assertEquals(FileUtils.readFileToString(file, Charset.forName(fileEncoding)), "Version=1.0." + build.getNumber());
+    }
+
+    @Test
+    public void testBuildVerbose() throws Exception {
+        configs.get(0).getConfigs().get(0).setVerbose(true);
+        FreeStyleProject project = jenkins.createFreeStyleProject();
+        ContentReplaceBuilder builder = new ContentReplaceBuilder(configs);
+        project.getBuildersList().add(builder);
+
+        FreeStyleBuild build = jenkins.buildAndAssertSuccess(project);
+        jenkins.assertLogContains("   > replace : [Version=0.0.0] => [Version=1.0." + build.getNumber() + "]", build);
         jenkins.assertLogContains("   > replace times: 1, [(Version=)\\d+.\\d+.\\d+] => [$11.0." + build.getNumber() + "]", build);
         Assert.assertEquals(FileUtils.readFileToString(file, Charset.forName(fileEncoding)), "Version=1.0." + build.getNumber());
     }


### PR DESCRIPTION
Turned off the log printed each time an occurence is replaced. 
Provided a new parameter `verbose` in FileContentReplaceItemConfig, disabled by default, that allows restoring this log.
The need emerged because these entries generated 2GB of trash in the logs of our builds, for we needed to replace outdated workspaces directories in several reports generated from other pipeline stages.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue