### PR TITLE
JENKINS-70550 Replace Deprecated IOUtils.LINE_SEPARATOR

### DIFF
--- a/src/main/java/com/mxstrive/jenkins/plugin/contentreplace/ContentReplaceBuilder.java
+++ b/src/main/java/com/mxstrive/jenkins/plugin/contentreplace/ContentReplaceBuilder.java
@@ -144,7 +144,7 @@ public class ContentReplaceBuilder extends Builder implements SimpleBuildStep {
 						+ replace + "]");
 			}
 		}
-		String content = StringUtils.join(lines, IOUtils.LINE_SEPARATOR);
+		String content = StringUtils.join(lines, System.lineSeparator());
 		filePath.write(content, config.getFileEncoding());
 		return true;
 	}


### PR DESCRIPTION

Replace deprecated IOUtils.LINE_SEPARATOR with System.lineSeparator()

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
