### PR TITLE
Closing file input streams safely (using try-with-resources)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .settings/
+.devcontainer/
+.vscode/
 target/
 work/

--- a/src/main/java/com/mxstrive/jenkins/plugin/contentreplace/ContentReplaceBuilder.java
+++ b/src/main/java/com/mxstrive/jenkins/plugin/contentreplace/ContentReplaceBuilder.java
@@ -111,10 +111,11 @@ public class ContentReplaceBuilder extends Builder implements SimpleBuildStep {
 	private boolean replaceFileContent(FilePath filePath, FileContentReplaceConfig config, EnvVars envVars,
 			FilePath workspace, TaskListener listener) throws InterruptedException, IOException {
 		PrintStream log = listener.getLogger();
+		Charset charset = Charset.forName(config.getFileEncoding());
 		List<String> lines = Collections.emptyList();
 		try (InputStream is = filePath.read();
 				InputStreamReader isr = new InputStreamReader(is, charset);) {
-			lines = readLines(isr, Charset.forName(config.getFileEncoding()));
+			lines = readLines(isr);
 		}
 		listener.getLogger().println(" > replace content of file: " + filePath);
 		for (FileContentReplaceItemConfig cfg : config.getConfigs()) {

--- a/src/main/java/com/mxstrive/jenkins/plugin/contentreplace/FileContentReplaceConfig.java
+++ b/src/main/java/com/mxstrive/jenkins/plugin/contentreplace/FileContentReplaceConfig.java
@@ -1,7 +1,5 @@
 package com.mxstrive.jenkins.plugin.contentreplace;
 
-import java.nio.charset.StandardCharsets;
-import java.nio.charset.spi.CharsetProvider;
 import java.util.Arrays;
 import java.util.List;
 


### PR DESCRIPTION
Streams are not properly being closed in case of an error, or at least it is up to the finalization of a class and thus the garbage collector. To make things safer, I used try-with-resources to properly close the input streams. Furthermore, unused imports were removed.

### Testing done

The changed lines are covered by the existing unit tests.
