### PR TITLE
bugfix/jenkins-71382/master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .settings/
+.devcontainer/
+.vscode/
 target/
 work/

--- a/src/main/java/com/mxstrive/jenkins/plugin/contentreplace/ContentReplaceBuilder.java
+++ b/src/main/java/com/mxstrive/jenkins/plugin/contentreplace/ContentReplaceBuilder.java
@@ -157,14 +157,15 @@ public class ContentReplaceBuilder extends Builder implements SimpleBuildStep {
 	private List<String> readLines(InputStreamReader isr) throws IOException {
 		List<String> ss = new ArrayList<>();
 		StringBuilder sb = new StringBuilder();
-		char cr = 0;
-		while (isr.ready()) {
-			cr = (char) isr.read();
+
+		int next;
+		while ((next = isr.read()) != -1) {
+			char cr = (char) next;
 			if (cr == '\r') {
 				continue;
 			} else if (cr == '\n') {
 				ss.add(sb.toString());
-				sb.delete(0, sb.length());
+				sb.setLength(0);
 			} else {
 				sb.append(cr);
 			}

--- a/src/main/java/com/mxstrive/jenkins/plugin/contentreplace/ContentReplaceBuilder.java
+++ b/src/main/java/com/mxstrive/jenkins/plugin/contentreplace/ContentReplaceBuilder.java
@@ -1,5 +1,6 @@
 package com.mxstrive.jenkins.plugin.contentreplace;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -113,8 +114,8 @@ public class ContentReplaceBuilder extends Builder implements SimpleBuildStep {
 		PrintStream log = listener.getLogger();
 		Charset charset = Charset.forName(config.getFileEncoding());
 		List<String> lines = Collections.emptyList();
-		try (InputStream is = filePath.read();
-				InputStreamReader isr = new InputStreamReader(is, charset);) {
+		try (BufferedInputStream bis = new BufferedInputStream(filePath.read());
+				InputStreamReader isr = new InputStreamReader(bis, charset);) {
 			lines = readLines(isr);
 		}
 		listener.getLogger().println(" > replace content of file: " + filePath);
@@ -207,8 +208,7 @@ public class ContentReplaceBuilder extends Builder implements SimpleBuildStep {
 		}
 		FilePath[] matchedFilePaths = null;
 		try {
-			matchedFilePaths = workspace.child(basePath)
-					.list(path.substring(basePath.equals("") ? 0 : basePath.length() + 1));
+			matchedFilePaths = workspace.child(basePath).list(path.substring(basePath.equals("") ? 0 : basePath.length() + 1));
 		} catch (Exception e) {
 			e.printStackTrace();
 			listener.getLogger().println("   > " + path + " list file fail");

--- a/src/main/java/com/mxstrive/jenkins/plugin/contentreplace/ContentReplaceBuilder.java
+++ b/src/main/java/com/mxstrive/jenkins/plugin/contentreplace/ContentReplaceBuilder.java
@@ -111,10 +111,11 @@ public class ContentReplaceBuilder extends Builder implements SimpleBuildStep {
 	private boolean replaceFileContent(FilePath filePath, FileContentReplaceConfig config, EnvVars envVars,
 			FilePath workspace, TaskListener listener) throws InterruptedException, IOException {
 		PrintStream log = listener.getLogger();
+		Charset charset = Charset.forName(config.getFileEncoding());
 		List<String> lines = Collections.emptyList();
 		try (InputStream is = filePath.read();
 				InputStreamReader isr = new InputStreamReader(is, charset);) {
-			lines = readLines(isr, Charset.forName(config.getFileEncoding()));
+			lines = readLines(isr);
 		}
 		listener.getLogger().println(" > replace content of file: " + filePath);
 		for (FileContentReplaceItemConfig cfg : config.getConfigs()) {

--- a/src/main/java/com/mxstrive/jenkins/plugin/contentreplace/FileContentReplaceConfig.java
+++ b/src/main/java/com/mxstrive/jenkins/plugin/contentreplace/FileContentReplaceConfig.java
@@ -1,7 +1,5 @@
 package com.mxstrive.jenkins.plugin.contentreplace;
 
-import java.nio.charset.StandardCharsets;
-import java.nio.charset.spi.CharsetProvider;
 import java.util.Arrays;
 import java.util.List;
 


### PR DESCRIPTION
Fixing issue: [JENKINS-71382](https://issues.jenkins.io/browse/JENKINS-71382)
Problem: "contentReplace 1.8.0 generates an empty file, 1.7.0 works ok"

The main issue is the use of the `ready()` method of the InputStream of the file to be read, which does not tell whether the end of a stream has been reached. To find that out, a check for the value `-1` (according to the [official documentation by Oracle](https://docs.oracle.com/javase/8/docs/api/java/io/InputStream.html#read--) needs to be implemented instead. `ready()` merely tells whether reading from a stream is going to block or not. However, since reading the file is absolutely mandatory in this case, there is no point in not reading the file (should the underlying stream not be ready).

### Testing done

Tested in private Jenkins instance. Lines are also covered by unit tests.

```
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] [not relevant] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
